### PR TITLE
FilterProcessor change to support queries with 'Like' operator 

### DIFF
--- a/src/Processor/FilterProcessor.php
+++ b/src/Processor/FilterProcessor.php
@@ -19,6 +19,16 @@ class FilterProcessor implements ProcessorInterface
         $value = $operation->getValue();
         $operator = $operation->getOperator();
         $field = $operation->getField();
+        if($operator == FilterOperation::STR_STARTS_WITH){
+            $operator = FilterOperation::OPERATOR_LIKE;
+            $value  = $value."%";
+        }else if($operator == FilterOperation::STR_ENDS_WITH){
+            $operator = FilterOperation::OPERATOR_LIKE;
+            $value  = "%".$value;
+        }else if($operator == FilterOperation::STR_CONTAINS){
+            $operator = FilterOperation::OPERATOR_LIKE;
+            $value  = "%".$value."%";
+        }
         $src->where($field, $operator, $value);
         return $src;
     }


### PR DESCRIPTION
Added support for these three operations

FilterOperation::STR_STARTS_WITH
FilterOperation::STR_ENDS_WITH
FilterOperation::STR_CONTAINS

didn't remove FilterOperation::OPERATOR_LIKE yet will remove it later.
